### PR TITLE
Introduction support multiligne pour les factures 

### DIFF
--- a/src/customerView.cpp
+++ b/src/customerView.cpp
@@ -1685,11 +1685,17 @@ void customerView::on_paintPrinterInvoice(QPrinter *printer)
 		for(int itemOnpage=0; itemOnpage<itemPerPage;){
 			//sil ne reste plus a afficher on sort
 			if((ilist.name.count() - pIndex) <= 0)break;
-			rect.translate( 0, rect.height()+5);
+            rect.translate( 0, rect.height()+5);
+
+            if (pIndex>0){
+                QStringList lines = ilist.name.at(pIndex-1).split("\n");
+                lines.count();
+                rect.translate( 0, (lines.count()-1)*rect.height());
+            }
 
 			//DESIGNATION 40%
 			rect = fm.boundingRect(mLeft+5,rect.top(), wUtil*0.40,0, Qt::AlignLeft, ilist.name.at(pIndex) );
-			rect.setWidth(wUtil*0.50); //fixe la largeur
+            rect.setWidth(wUtil*0.50); //fixe la largeur
 			painter.drawText( rect,  Qt::AlignLeft , ilist.name.at(pIndex));
 
 			//TVA 12%
@@ -1697,7 +1703,7 @@ void customerView::on_paintPrinterInvoice(QPrinter *printer)
 				rect = fm.boundingRect(mLeft-5+(wUtil*0.40),rect.top(), wUtil*0.12,0, Qt::AlignRight, m_lang.toString(ilist.tax.at(pIndex),'f',2) );
 				//rect.setWidth(wUtil*0.12 -5); //fixe la largeur
 				painter.drawText( rect,  Qt::AlignRight , m_lang.toString(ilist.tax.at(pIndex),'f',2) );
-			}
+            }
 
 			//REMISE 12%
 			if(discount){

--- a/src/dialoginvoice.cpp
+++ b/src/dialoginvoice.cpp
@@ -364,15 +364,19 @@ void DialogInvoice::listInvoiceDetailsToTable(QString filter, QString field)
 		//definir le tableau
 		ui->tableWidget->setRowCount(i+1);
 
+        QTextEdit *edit_name = new QTextEdit();
+        edit_name->setText(item_NAME->text());
+
 		//remplir les champs
 		ui->tableWidget->setItem(i, COL_ID, item_ID);
 		ui->tableWidget->setItem(i, COL_ID_PRODUCT, item_ID_PRODUCT);
 		ui->tableWidget->setItem(i, COL_ORDER, item_ORDER);
-		ui->tableWidget->setItem(i, COL_NAME, item_NAME);
+        ui->tableWidget->setCellWidget(i,COL_NAME,edit_name);
 		ui->tableWidget->setItem(i, COL_TAX, item_TAX);
 		ui->tableWidget->setItem(i, COL_DISCOUNT, item_DISCOUNT);
 		ui->tableWidget->setItem(i, COL_PRICE, item_PRICE);
 		ui->tableWidget->setItem(i, COL_QUANTITY, item_QUANTITY);
+
 	}
 	ui->tableWidget->setSortingEnabled(true);
 	ui->tableWidget->selectRow(0);
@@ -589,7 +593,9 @@ void DialogInvoice::updateInvoiceItems(){
 			}
 		}
 
-		itemInv.name = ui->tableWidget->item(j, COL_NAME)->text();
+
+        QTextEdit *get_name = qobject_cast<QTextEdit*>(ui->tableWidget->cellWidget(j, COL_NAME));
+        itemInv.name = get_name->toPlainText();
 		itemInv.tax = ui->tableWidget->item(j, COL_TAX)->text().toFloat();
 		itemInv.discount = ui->tableWidget->item(j, COL_DISCOUNT)->text().toInt();
 		itemInv.price = ui->tableWidget->item(j, COL_PRICE)->text().toFloat();

--- a/src/dialoginvoice.h
+++ b/src/dialoginvoice.h
@@ -4,6 +4,7 @@
 #include <QDialog>
 #include <QList>
 #include <QTableWidgetItem>
+#include <QTextEdit>
 
 #include "dbase.h"
 #include "productView.h"


### PR DESCRIPTION
Un début de support pour les descriptions multilignes dans les factures.

A voir si c'est satisfaisant, pour le moment ce n'est appliqué que sur les factures éditées manuellement (pas sur les produits, services...).

L'impression est aussi prise en compte mais ça sera également à compléter pour que les factures avec plusieurs pages soit bien géré (se baser sur nombre total de ligne des éléments au lieu du nombre d'élement)
